### PR TITLE
replace missing angular-storage 0.5.0 with a0-angular-storage 0.0.15

### DIFF
--- a/00-Starter-Seed/bower.json
+++ b/00-Starter-Seed/bower.json
@@ -21,6 +21,6 @@
     "angular-jwt": "~0.1.0",
     "angular-route": "~1.5.8",
     "bootstrap": "~3.3.7",
-    "angular-storage": "~0.5.0"
+    "a0-angular-storage": "~0.0.15"
   }
 }


### PR DESCRIPTION
May need to do this in other samples' bower.json, too, as it appears `angular-storage` no longer exists in bower's index. Replacing with `a0-angular-storage` works.
